### PR TITLE
Fix definition of DESC_RTD_TEAM

### DIFF
--- a/scripting/rtd.sp
+++ b/scripting/rtd.sp
@@ -136,7 +136,7 @@ Handle g_hCvarShowTime;				bool g_bCvarShowTime = false;
 #define DESC_SHOW_TIME "0/1 - Should time the perk was applied for be displayed?"
 
 Handle g_hCvarRtdTeam;				int g_iCvarRtdTeam = 0;
-#define DESC_RTD_TEAM "0 - both teams can roll, 1 - only RED team can roll, 2 - only BLU team can roll."
+#define DESC_RTD_TEAM "0 - both teams can roll, 1 - only BLU team can roll, 2 - only RED team can roll."
 Handle g_hCvarRtdMode;				int g_iCvarRtdMode = 0;
 #define DESC_RTD_MODE "0 - No restrain except the interval, 1 - Limit by rollers, 2 - Limit by rollers in team."
 Handle g_hCvarClientLimit;			int g_iCvarClientLimit = 2;


### PR DESCRIPTION
Definition of DESC_RTD_TEAM is wrong. so server admins like me might wonder why team limitations doesn't work as expected. It's correct in the Wiki though.