### PR TITLE
Change some defaults

### DIFF
--- a/configs/rtd2_perks.default.cfg
+++ b/configs/rtd2_perks.default.cfg
@@ -56,7 +56,7 @@
 		{
 			"radius"		"128.0"
 			"interval"		"0.2"
-			"damage"		"20.0"
+			"damage"		"50.0"
 		}
 		"tags"			"toxic, gas, smoke, hurt, good"
 		"call"			"Toxic_Call"
@@ -235,7 +235,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"level"			"2" // sentry level
+			"level"			"3" // sentry level
 			"keep"			"0" // keep sentry after perk's end
 			"amount"		"1" // how many sentries can be placed
 		}
@@ -254,7 +254,7 @@
 		"weapons"		"rocketl, particle_c, flaregun, crossbow, compound"
 		"settings"
 		{
-			"crits"			"0" // 0 = no Crits, 1 = MiniCrits, 2 = FullCrits
+			"crits"			"1" // 0 = no Crits, 1 = MiniCrits, 2 = FullCrits
 		}
 		"tags"			"homingprojectiles, crits, crit, criticals, critical, homing, projectile, projectiles, rocket, flare, arrow, rockets, flares, arrows, good"
 		"call"			"HomingProjectiles_Call"
@@ -328,7 +328,7 @@
 		"settings"
 		{
 			"radius"		"512.0"
-			"damage"		"270.0"
+			"damage"		"450.0"
 		}
 		"tags"			"timebomb, time, bomb, explode, death, die, notimer, bad"
 		"call"			"Timebomb_Call"
@@ -358,7 +358,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"health"		"7"
+			"health"		"1"
 		}
 		"tags"			"lowhealth, low, health, notimer, bad"
 		"call"			"LowHealth_Call"
@@ -492,7 +492,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"fov"			"160"
+			"fov"			"180"
 		}
 		"tags"			"funnyfeeling, funny, feeling, cow, moo, high, fov, screen, bad"
 		"call"			"FunnyFeeling_Call"
@@ -594,7 +594,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"scale"			"0.15"
+			"scale"			"0.1"
 		}
 		"tags"			"tinymann, tinyman, tiny, man, player, mann, resize, good"
 		"call"			"TinyMann_Call"
@@ -630,7 +630,7 @@
 		{
 			"rate"			"0.8"
 			"range"			"196.0"
-			"damage"		"72.0"
+			"damage"		"100.0"
 		}
 		"tags"			"deadly, voice, voicecommand, command, scream, shout, impact, damage, good"
 		"call"			"DeadlyVoice_Call"
@@ -677,7 +677,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"multiplier"	"2.5"
+			"multiplier"	"3.0"
 		}
 		"tags"			"weakened, weak, week, incoming, damage, hit, bad"
 		"call"			"Weakened_Call"
@@ -724,9 +724,9 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"delay"			"12.0" // seconds before suffocation kicks in
+			"delay"			"0" // seconds before suffocation kicks in
 			"rate"			"1.0"
-			"damage"		"5"
+			"damage"		"2"
 		}
 		"tags"			"suffocation, drown, drowning, suffocate, breathing, breath, loss, lack, air, bad"
 		"call"			"Suffocation_Call"
@@ -774,7 +774,7 @@
 		"weapons"		"0"
 		"settings"
 		{
-			"health"		"300" // How much more health should the player have
+			"health"		"500" // How much more health should the player have
 		}
 		"tags"			"vital, increase, more, maximum, max, health, heal, life, good"
 		"call"			"Vital_Call"
@@ -805,7 +805,7 @@
 		"settings"
 		{
 			"range"			"270"
-			"crits"			"1" // 1 - full crits, 0 mini crits
+			"crits"			"1" // 1 - full crits, 0 - minicrits
 		}
 		"tags"			"teamcriticals, team, criticals, crits, crit, critical, hit, hits, teammate, tammates, good"
 		"call"			"TeamCriticals_Call"
@@ -840,7 +840,7 @@
 		"settings"
 		{
 			"rate"			"2.0"
-			"crit"			"0.05" // chance for a crit
+			"crit"			"0.3" // chance for a crit
 		}
 		"tags"			"firebreath, fire, breath, breathe, ball, fireball, voice, voicecommand, command, shout, impact, damage, good"
 		"call"			"FireBreath_Call"
@@ -914,7 +914,7 @@
 		"settings"
 		{
 			"damage"		"100"
-			"radius"		"80"
+			"radius"		"100"
 			"force"			"100"
 		}
 		"tags"			"explosivearrows, explosive, arrow, arrows, bolt, bolts, impact, expload, explosion, huntsman, medic, sniper, good"
@@ -1003,7 +1003,7 @@
 		{
 			"rate"			"2.0"
 			"speed"			"1100" // 1100 - rocket's speed
-			"damage"		"150"
+			"damage"		"200"
 		}
 		"tags"			"hatthrow, hat, throw, gibus, ghastly, cosmetic, good"
 		"call"			"HatThrow_Call"
@@ -1023,8 +1023,8 @@
 			"rate"			"2.0"
 			"delay"			"1.0" // delay before the attack
 			"range"			"100"
-			"damage"		"150" // int
-			"selfdamage"	"150" // int
+			"damage"		"450" // int
+			"selfdamage"	"450" // int
 		}
 		"tags"			"madaraswhistle, madaras, whistle, gator, alligator, croc, crocodile, summon, bloodborne, halloween, good"
 		"call"			"MadarasWhistle_Call"
@@ -1073,7 +1073,7 @@
 		"settings"
 		{
 			"protection"	"3.0" // Seconds of ubercharge after resurrection
-			"health"		"80" // Percentage of max health after resurrection
+			"health"		"100" // Percentage of max health after resurrection
 		}
 		"tags"			"mercsdietwice, mercs, merc, shadows, die, twice, revice, death, sekiro, good"
 		"call"			"MercsDieTwice_Call"
@@ -1183,9 +1183,9 @@
 		"settings"
 		{
 			"rate"				"3.0" // rate of fire
-			"range"				"150.0" // explosion range
-			"damage"			"80.0" // damage per pumpkin
-			"amount"			"5" // amount of pumpkins spawned
+			"range"				"250.0" // explosion range
+			"damage"			"100.0" // damage per pumpkin
+			"amount"			"3" // amount of pumpkins spawned
 		}
 		"tags"			"pumpkintrail, pumpkin, trail, pumpkins, pumpking, pumpkings, voice, halloween, good"
 		"call"			"PumpkinTrail_Call"


### PR DESCRIPTION
I am suggesting this changes because I think that with these changes the plugin would be better.

- Increased toxic damage from 20 to 50.
- Increased the Sentry level from 2 to 3 on the Spawn Sentry effect.
- Enabled minicrits on the Homing Projectiles effect.
- Increased timebomb damage from 270 to 450.
- Changed the amount of health in Low Health from 7 to 1.
- Increased the Funny Feeling FOV from 160 to 180 (90*2).
- Reduced scale on the Tiny Mann effect from 0.15 to 0.1.
- Increased Deadly Voice damage from 72 to 100.
- Increased Weakened effect multiplier to 3.
- Removed delay from Suffocation.
- Reduced Suffocation damage from 5 to 2.
- Increased Vital health amount from 300 to 500.
- Increased Fire Breath crit chance to 30%.
- Increased Explosive Arrows radius from 80 to 100.
- Increased Hat Throw damage to 200.
- Increased Madaras Whistle damage and self-damage from 150 to 450.
- Increased Mercs Die Twice health percentage from 80% to 100%.
- Increased Pumpkin Trail range from 150 to 250.
- Increased Pumpkin Trail damage from 80 to 100.
- Reduced Pumpkin Trail pumpkins amount spawned from 5 to 3.