### PR TITLE
fix: sm_rtd2_insetup doesn't work in mvm

### DIFF
--- a/scripting/rtd.sp
+++ b/scripting/rtd.sp
@@ -1594,7 +1594,7 @@ bool IsPlayerFriendly(int client){
 }
 
 bool IsRTDInRound(){
-	if(GameRules_GetProp("m_bInWaitingForPlayers", 1))
+	if(!GameRules_GetProp("m_bPlayingMannVsMachine") && GameRules_GetProp("m_bInWaitingForPlayers", 1))
 		return false;
 
 	if(!g_bCvarInSetup){


### PR DESCRIPTION
Looks like the game is always "waiting for players" before the round starts in mvm mode, so we should exclude mvm in this condition.

Closes #11 