### PR TITLE
fix Property "m_iPlayerIndex" not found (entity 346/tf_ragdoll)

### DIFF
--- a/scripting/rtd/stocks.sp
+++ b/scripting/rtd/stocks.sp
@@ -455,7 +455,7 @@ stock int CreateRagdoll(int client, bool bFrozen=false){
 
 	TeleportEntity(iRag, fPos, fAng, fVel);
 
-	SetEntProp(iRag, Prop_Send, "m_iPlayerIndex", client);
+	SetEntProp(iRag, Prop_Send, "m_iPlayer", client);
 	SetEntProp(iRag, Prop_Send, "m_bIceRagdoll", bFrozen);
 	SetEntProp(iRag, Prop_Send, "m_iTeam", GetClientTeam(client));
 	SetEntProp(iRag, Prop_Send, "m_iClass", view_as<int>(TF2_GetPlayerClass(client)));


### PR DESCRIPTION
fix against the latest tf2 vscript update.

[SM] Exception reported: Property "m_iPlayerIndex" not found (entity 243/tf_ragdoll)
[SM] Blaming: rtd.smx
[SM] Call stack trace:
[SM] [0] SetEntProp
[SM] [1] Line 458, rtd/stocks.sp::CreateRagdoll
[SM] [2] Line 82, rtd/perks/mercsdietwice.sp::MercsDieTwice_FakeDeath
[SM] [3] Line 68, rtd/perks/mercsdietwice.sp::MercsDieTwice_PlayerHurt
[SM] [4] Line 150, rtd/manager.sp::Forward_PlayerHurt
[SM] [5] Line 803, rtd.sp::Event_PlayerHurt