### PR TITLE
"RTD still persists on Spectator" fix

### DIFF
--- a/scripting/rtd.sp
+++ b/scripting/rtd.sp
@@ -1247,6 +1247,12 @@ public Action Timer_Countdown(Handle hTimer, int iSerial){
 	if(client == 0)
 		return Plugin_Stop;
 
+	if(TF2_GetClientTeam(client) == TFTeam_Spectator)
+	{
+		ForceRemovePerk(client, RTDRemove_Death);
+		return Plugin_Stop;
+	}
+
 	if(!g_hRollers.GetInRoll(client))
 		return Plugin_Stop;
 


### PR DESCRIPTION
Fixed the bug that allowed players who switched to the spectators to continue using perks.

Closes #48